### PR TITLE
Add validation split + update notebook

### DIFF
--- a/reuters_text.ipynb
+++ b/reuters_text.ipynb
@@ -27,9 +27,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[nltk_data] Downloading package reuters to /home/matyi/nltk_data...\n",
+      "[nltk_data] Downloading package reuters to /home/mat/nltk_data...\n",
       "[nltk_data]   Package reuters is already up-to-date!\n",
-      "[nltk_data] Downloading package punkt to /home/matyi/nltk_data...\n",
+      "[nltk_data] Downloading package punkt to /home/mat/nltk_data...\n",
       "[nltk_data]   Package punkt is already up-to-date!\n"
      ]
     }
@@ -51,7 +51,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/matyi/university/ATCS_group1/venv/lib/python3.8/site-packages/torchtext/data/field.py:150: UserWarning: Field class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
+      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/field.py:150: UserWarning: Field class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
       "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
      ]
     }
@@ -72,14 +72,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/matyi/university/ATCS_group1/venv/lib/python3.8/site-packages/torchtext/data/example.py:78: UserWarning: Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
+      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/example.py:78: UserWarning: Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
       "  warnings.warn('Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.', UserWarning)\n"
      ]
     }
    ],
    "source": [
-    "r52_train, r52_test = R52.splits(ID, TEXT, LABEL)\n",
-    "r8_train,  r8_test  = R8.splits(ID, TEXT, LABEL)"
+    "r52_train, r52_test, r52_val = R52.splits(ID, TEXT, LABEL, val_size=0.1)\n",
+    "r8_train,  r8_test, r8_val  = R8.splits(ID, TEXT, LABEL, val_size=0.1)"
    ]
   },
   {
@@ -93,11 +93,13 @@
      "output_type": "stream",
      "text": [
       "R8\n",
-      "train size: 5501  instead of 5485\n",
+      "train size: 4951  instead of 5485\n",
       "test size: 2190  instead of 2189\n",
+      "val size: 550\n",
       "R52\n",
-      "train size: 6560  instead of 6532\n",
-      "test size: 2570  instead of 2568\n"
+      "train size: 5904  instead of 6532\n",
+      "test size: 2570  instead of 2568\n",
+      "val size: 656\n"
      ]
     }
    ],
@@ -105,10 +107,12 @@
     "print('R8')\n",
     "print('train size:', len(r8_train), ' instead of 5485')\n",
     "print('test size:', len(r8_test), ' instead of 2189')\n",
+    "print('val size:', len(r8_val))\n",
     "\n",
     "print('R52')\n",
     "print('train size:', len(r52_train), ' instead of 6532')\n",
-    "print('test size:', len(r52_test), ' instead of 2568')"
+    "print('test size:', len(r52_test), ' instead of 2568')\n",
+    "print('val size:', len(r52_val))"
    ]
   },
   {
@@ -133,13 +137,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/matyi/university/ATCS_group1/venv/lib/python3.8/site-packages/torchtext/data/iterator.py:48: UserWarning: BucketIterator class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
+      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/iterator.py:48: UserWarning: BucketIterator class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
       "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
      ]
     }
    ],
    "source": [
-    "r52_train_iter, r52_test_iter = BucketIterator.splits((r52_train, r52_test), batch_size=4)"
+    "r52_train_iter, r52_test_iter, r52_val_iter = BucketIterator.splits(\n",
+    "    (r52_train, r52_test, r52_val), \n",
+    "    batch_size=4,\n",
+    "    sort=False\n",
+    ")"
    ]
   },
   {
@@ -155,66 +163,86 @@
       "\n",
       "[torchtext.data.batch.Batch of size 4]\n",
       "\t[.id]:[torch.LongTensor of size 4]\n",
-      "\t[.text]:('[torch.LongTensor of size 4x115]', '[torch.LongTensor of size 4]')\n",
+      "\t[.text]:('[torch.LongTensor of size 4x489]', '[torch.LongTensor of size 4]')\n",
       "\t[.label]:[torch.LongTensor of size 4]\n",
-      "tensor([5630, 5824,  981, 4739])\n",
-      "tensor([ 2, 21,  2,  1])\n",
-      "These two labels should be the same: acq == acq\n",
-      "(tensor([[ 3007, 19260,    20,    22,    19, 13461,    26,     6,   226,   571,\n",
-      "           267,     6,  7674,  3007,   256,    46,     9,    29, 10104,    58,\n",
-      "           282,   215,     6,   226,    29, 14739,  4388,  1444,   195,     7,\n",
-      "          1206,     6, 11814,     3,  1960,    14,   259,  7674,    58,     3,\n",
-      "            16,   814,   324,     2,  1200,     5,     4,   362,   504,    32,\n",
-      "           467,     6,   427,    35,     4,  1737,   129,     3,    17,     9,\n",
+      "tensor([1666, 2736, 4494, 1235])\n",
+      "tensor([ 3,  2, 25,  2])\n",
+      "['crude']\n",
+      "crude\n",
+      "These two labels should be the same: crude == crude\n",
+      "(tensor([[2396,  380, 4430,  ...,    1,    1,    1],\n",
+      "        [ 949,   20,   21,  ..., 1286,  928,    2],\n",
+      "        [ 235,   99,  793,  ...,    1,    1,    1],\n",
+      "        [8752, 5676,   10,  ...,    1,    1,    1]]), tensor([111, 489,  40,  22]))\n",
+      "\n",
+      "[torchtext.data.batch.Batch of size 4]\n",
+      "\t[.id]:[torch.LongTensor of size 4]\n",
+      "\t[.text]:('[torch.LongTensor of size 4x899]', '[torch.LongTensor of size 4]')\n",
+      "\t[.label]:[torch.LongTensor of size 4]\n",
+      "tensor([0, 0, 0, 0])\n",
+      "tensor([4, 4, 4, 4])\n",
+      "(tensor([[1989, 1201, 3241,  ...,    4, 1065,    2],\n",
+      "        [ 130,  629,  891,  ...,    1,    1,    1],\n",
+      "        [ 239,  187, 1475,  ...,    1,    1,    1],\n",
+      "        [ 130,  629,  891,  ...,    1,    1,    1]]), tensor([899, 233, 257, 233]))\n",
+      "\n",
+      "[torchtext.data.batch.Batch of size 4]\n",
+      "\t[.id]:[torch.LongTensor of size 4]\n",
+      "\t[.text]:('[torch.LongTensor of size 4x101]', '[torch.LongTensor of size 4]')\n",
+      "\t[.label]:[torch.LongTensor of size 4]\n",
+      "tensor([0, 0, 0, 0])\n",
+      "tensor([ 2, 11,  1,  1])\n",
+      "(tensor([[    0,    10,  3867,     0,  1127,   332,    20,    21,    19,     0,\n",
+      "            57,    26,    10,     4,    20,    21,    19,  3867,  1008,     2,\n",
+      "             0,    57,    26,    77,   857,    27,   155,   338,    14,   287,\n",
+      "           332,     5,   144,     5,     4,  1765,  5008,  2391,     5,  1144,\n",
+      "           579,    57,     2,     0,     9,    17,    10,     4,     0,   497,\n",
+      "            38,   363,   804,     8,   133,    23,  1550,   167,     7,     4,\n",
+      "          5008,  2391,     2,     0,  2722,   287,    33,     3,    56,  1122,\n",
+      "            35,     8,    64,   121,     3,    17,    49,  1781,    54,   569,\n",
+      "           133,    11,    15,     5,   242,     6,  1144,     2,     0,   416,\n",
+      "          1144,   579,    57,   179,    71,    28,     3,     4,    42,     9,\n",
+      "             2],\n",
+      "        [14502,  3724,    57,   702,   275,  3351, 14502,  3724,    57,     9,\n",
+      "           428,  1180,    27,     4, 13091,  9713,  1091,  1024,     4,   370,\n",
+      "            14,  1401, 13275,   137,     8,  6324,     5,   616,  1025,     2,\n",
+      "          3351,  5329,    30,    80,    87,     2,   335,  1038,     5,   275,\n",
+      "           100,   452,  1163,   137,     8,   704,    14,  3116,  7963,    37,\n",
+      "             8,  2670,     5,  1336,     6,   357,  1025,     6,    80,    24,\n",
+      "             2,    24,  1038,     5,   275,   100,  1163,   137,     8,   568,\n",
+      "            14,  3116,  7963,    37,     8,  2670,     5,   522,     6,  3773,\n",
+      "          1025,     2,     1,     1,     1,     1,     1,     1,     1,     1,\n",
+      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
+      "             1],\n",
+      "        [    0,  1838,    20,    21,    19,     0,    26,   305,   822,   135,\n",
+      "             0,  1838,    57,     9,    29,   148,   701,    54,   822,   317,\n",
+      "           135,     5,    90,    25,   100,    60,     3,    29,   107,   519,\n",
+      "             3,   430,    91,   356,     6,   623,     5,   124,    91,   129,\n",
       "             2,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
       "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
       "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
       "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
       "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1],\n",
-      "        [ 1913,  6458,  1663,   775,    10,  3220,  2064,     8,  1913,    33,\n",
-      "           964,   381,   717,   358,    32,  7572, 14123,    10,   775,  4424,\n",
-      "             7,  1422,    10,   251,     9,    17,   158,    72,   495,   112,\n",
-      "             2,     4,   129,    32,  7909,  1664,   202, 20931,  5991,     7,\n",
-      "          1497,     5,  7702,     3,  1492,    10,   828,  6576,     3,    66,\n",
-      "            57,  1239,     6,  4039,  1417,     3,   602,     6,   895,   968,\n",
-      "             2,   188,    49,   114,   143,   178,   903,     5,  1579,     2,\n",
-      "           251,     5,  1422,    18,    13,  3127,    14,   525,   765,     9,\n",
-      "            29, 12125,   158,   492,   840,   217,   989, 12610,    83,  5602,\n",
-      "            16,   489,     6,  5740,    40,  3127,    14,   525,  1491,     2,\n",
-      "          1422,    49,     8, 21515,  1112,    33,  2669,  1661,     7,   112,\n",
-      "            10,  9461,     6,   648,     2],\n",
-      "        [ 1612,    18,    13,  2221,  1234,  1473,   137,    47,     2,    13,\n",
-      "             2,  2871,    14,  2982,    58,    16,   637,    11,   987,    14,\n",
-      "           178,  1612,    18,    13,  2221,  1234,  1473,   137,    47,     2,\n",
-      "            13,     2,  2871,    14,  2982,    58,    16,   637,    11,   987,\n",
-      "            14,   178,     1,     1,     1,     1,     1,     1,     1,     1,\n",
       "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1],\n",
-      "        [11475,   786,   552,    97,    20,    22,    19, 14565,    26,  1571,\n",
-      "          1001,   264,   203,   808,     8,   300,     2,    50,    25,    12,\n",
-      "           346,     2,    54,    25,   184,   264,   203,   808,   697,    36,\n",
-      "             2,    50,    25,    12,    36,     2,    54,    25,   184,   168,\n",
-      "           413,    70,   121,   112,    70,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1]]), tensor([ 61, 115,  42,  45]))\n"
+      "             1],\n",
+      "        [ 3685,    20,    21,    19, 10330,    26,     6,   374,   276,    18,\n",
+      "            13,    67,  3685,    89,    46,     9,    17,   286,     6,   374,\n",
+      "           134,    23,     5,     4,   157,    68,     5,    29, 10219,  3286,\n",
+      "            89,    46,   159,     6,  3685,    89,   200,     2,     4,    42,\n",
+      "             9,    17,  1380,     6,   374,    70,    60,     5, 10219,  3286,\n",
+      "            16,   363,   188,  3685,    67,   378,     6,   200,     5,   124,\n",
+      "            91,   356,     2,     4,   642,    32,   832,    16,    98,   149,\n",
+      "             3,     4,    42,    88,     9,     2,    17,     9,     4, 10219,\n",
+      "            67,    38,    82,     7,     4,   137,    14,     4,    14,  2070,\n",
+      "            94,   164,     4,  9456,     0,     2,     1,     1,     1,     1,\n",
+      "             1]]), tensor([101,  82,  41,  96]))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/matyi/university/ATCS_group1/venv/lib/python3.8/site-packages/torchtext/data/batch.py:23: UserWarning: Batch class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
+      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/batch.py:23: UserWarning: Batch class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
       "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
      ]
     }
@@ -227,10 +255,26 @@
     "    print(x)\n",
     "    print(x.id)\n",
     "    print(x.label)\n",
+    "    print(reuters.categories(ID.vocab.itos[x.id[0]]))\n",
+    "    print(LABEL.vocab.itos[x.label[0]])\n",
     "    print('These two labels should be the same: {} == {}'.format(\n",
     "        reuters.categories(ID.vocab.itos[x.id[0]])[0],\n",
     "        LABEL.vocab.itos[x.label[0]]))\n",
     "\n",
+    "    print(x.text) # Padding is 1\n",
+    "    break\n",
+    "\n",
+    "for x in r52_test_iter:\n",
+    "    print(x)\n",
+    "    print(x.id)\n",
+    "    print(x.label)\n",
+    "    print(x.text) # Padding is 1\n",
+    "    break\n",
+    "    \n",
+    "for x in r52_val_iter:\n",
+    "    print(x)\n",
+    "    print(x.id)\n",
+    "    print(x.label)\n",
     "    print(x.text) # Padding is 1\n",
     "    break"
    ]
@@ -260,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As you mention in a comment, I added a way to make a validation split.
There was also an issue with the test iterator returned by ```BucketIterator.splits()``` in the notebook. It was throwing an error when trying to iterate over the test dataset. Following the suggestion [here](https://github.com/pytorch/text/issues/474#issuecomment-578359387) I removed the sorting of the batch.
Let me know if something is wrong.