### PR TITLE
Dataloading compatible with huggingface tokenizer

### DIFF
--- a/datasets/reuters_text.py
+++ b/datasets/reuters_text.py
@@ -5,35 +5,23 @@ import random
 import nltk
 nltk.download('reuters')
 from nltk.corpus import reuters
-nltk.download('punkt')
-from nltk import word_tokenize
 
-from torchtext.data import Dataset, Example
+from torch.utils.data import Dataset
+import torch
 
 
 class Reuters(Dataset):
-    def __init__(self, docs, fields, **kwargs):
-        """Initializes the Reuters dataset with the given documents and fields.
-
-        Args:
-            docs (list): List of documents to use.
-            fields (list): List of fields in a format such that "fromlist" can be called.
-        """
-        examples = []
-        for doc in docs:
-            example = [doc, ' '.join(reuters.words(doc)), reuters.categories(doc)[0]]
-            examples.append(Example.fromlist(example, fields))
-
-        super().__init__(examples, fields, **kwargs)
+    def __init__(self, encodings, labels, classes):
+        self.encodings = encodings
+        self.labels = labels
+        self.classes = classes
         
     @classmethod
-    def splits(cls, ID, TEXT, LABEL, r8=False, val_size=0.1):
-        """Creates the train and test splits for R52 or R8.
+    def splits(cls, tokenizer, r8=False, val_size=0.1):
+        """Creates the train, test, and validation splits for R52 or R8.
 
         Args:
-            ID (Field): Id field.
-            TEXT (Field): Text field.
-            LABEL (Field): Label field.
+            tokenizer (Tokenizer): Hugging Face tokenizer to encode the 3 dataset splits.
             r8 (bool, optional): If true, it initializes R8 instead of R52. Defaults to False.
             val_size (float, optional): Proportion of training documents to include in the validation set.
 
@@ -42,42 +30,43 @@ class Reuters(Dataset):
             test_split (Dataset): Test split.
             val_split (Dataset): Validation split.
         """        
-        train_docs, test_docs = cls.prepare_reuters(r8)
-        fields = [('id', ID), ('text', TEXT), ('label', LABEL)]
+        (train_docs, test_docs, val_docs), unique_cls = cls.prepare_reuters(r8, val_size)
         
-        # Select the validation documents out of the training documents
-        val_size = int(len(train_docs) * val_size)
-        random.shuffle(train_docs)
-        val_docs = train_docs[:val_size]
-        train_docs = train_docs[val_size:]
-        
-        train_split = cls(train_docs, fields)
-        test_split = cls(test_docs, fields)
-        val_split = cls(val_docs, fields)
-        return train_split, test_split, val_split
+        # Maybe this should be in a function
+        train_texts, train_labels = cls._prepare_split(train_docs, unique_cls)
+        train_encodings = tokenizer(train_texts, truncation=True, padding=True)
+        train_split = cls(train_encodings, train_labels, unique_cls)
 
+        test_texts, test_labels = cls._prepare_split(test_docs, unique_cls)
+        test_encodings = tokenizer(test_texts, truncation=True, padding=True)
+        test_split = cls(test_encodings, test_labels, unique_cls)
+
+        val_texts, val_labels = cls._prepare_split(val_docs, unique_cls)
+        val_encodings = tokenizer(val_texts, truncation=True, padding=True)
+        val_split = cls(val_encodings, val_labels, unique_cls)
+
+        return train_split, test_split, val_split
+    
     @staticmethod
-    def prepare_reuters(r8=False):
+    def prepare_reuters(r8=False, val_size=0.1):
         """Filters out all documents which have more or less than 1 class. Then filters out all classes which have no remaining documents.
 
         Args:
             r8 (bool, optional): R8 is constructed by taking only the top 10 (original) classes. Defaults to False.
+            val_size (float, optional): Proportion of training documents to include in the validation set.
 
         Returns:
-            train_docs (list): List of training documents.
-            test_docs (list): List of test documents.
+            doc_splits (tupple): Tupple containing 3 List of training, test, and validation documents.
+            unique_classes (List): List of Strings containing the class names sorted in alphabetical order.
         """    
         # Filter out docs which don't have exactly 1 class
         data = defaultdict(lambda: {'train': [], 'test': []})
         for doc in reuters.fileids():
-            # print("reuter field=", doc)
             if len(reuters.categories(doc)) == 1:
                 if doc.startswith('training'):
                     data[reuters.categories(doc)[0]]['train'].append(doc)
-                elif doc.startswith('test'):
+                if doc.startswith('test'):
                     data[reuters.categories(doc)[0]]['test'].append(doc)
-                else:
-                    print(doc)
 
         # Filter out classes which have no remaining docs
         for cls in reuters.categories():
@@ -92,8 +81,48 @@ class Reuters(Dataset):
         # Create splits
         train_docs = [doc for cls, splits in data.items() for doc in splits['train']]
         test_docs = [doc for cls, splits in data.items() for doc in splits['test']]
+
+        # Select the validation documents out of the training documents
+        val_size = int(len(train_docs) * val_size)
+        random.shuffle(train_docs)
+        val_docs = train_docs[:val_size]
+        train_docs = train_docs[val_size:]
+
+        # sort the unique classes to ensure constant order
+        unique_classes = sorted(data.keys())
+
+        return (train_docs, test_docs, val_docs), unique_classes
+    
+    @staticmethod
+    def _prepare_split(docs, classes):
+        """Extract the text and labels of each documents.
+
+        Args:
+            docs (List): List of document names from which the texts and labels will be extracted. 
+            classes (List): List of unique class names sorted in alphabetical order.
+
+        Returns:
+            texts (List): List of Strings containing the text of the documents.
+            labels (List): List of int containing the labels of the documents.
+        """   
+        texts = []
+        labels = []
+        for doc in docs:
+            text = ' '.join(reuters.words(doc))
+            cls = reuters.categories(doc)[0]
+            texts.append(text)
+            labels.append(classes.index(cls))
         
-        return train_docs, test_docs
+        return texts, labels
+    
+    def __getitem__(self, idx):
+        # assumes that the encodings were created using a HuggingFace tokenizer
+        item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
+        item["labels"] = torch.tensor(self.labels[idx])
+        return item
+    
+    def __len__(self):
+        return len(self.labels)
 
 
 class R52(Reuters):
@@ -118,3 +147,25 @@ class R8(Reuters):
     @classmethod
     def splits(cls, *args, **kwargs):
         return super().splits(r8=True, *args, **kwargs)
+
+if __name__ == "__main__":
+    from transformers import RobertaTokenizer
+    from torch.utils.data import DataLoader
+    tokenizer = RobertaTokenizer.from_pretrained("roberta-base")
+
+    trainset, testset, valset = R52.splits(tokenizer, val_size=0.1)
+    print("train size=", len(trainset))
+    print("test size=", len(testset))
+    print("val size=", len(valset))
+
+    trainloader = DataLoader(trainset, batch_size=2)
+
+    for data in trainloader:
+        input_ids = data["input_ids"]
+        attention_mask = data["attention_mask"]
+        labels = data["labels"]
+        print(input_ids)
+        print(attention_mask)
+        print(labels)
+        break
+

--- a/datasets/reuters_text.py
+++ b/datasets/reuters_text.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     print("test size=", len(testset))
     print("val size=", len(valset))
 
-    trainloader = DataLoader(trainset, batch_size=2)
+    trainloader = DataLoader(trainset, batch_size=2, shuffle=True)
 
     for data in trainloader:
         input_ids = data["input_ids"]

--- a/datasets/reuters_text.py
+++ b/datasets/reuters_text.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-from collections import defaultdict
 import random
+from collections import defaultdict
 
 import nltk
+import torch
+
 nltk.download('reuters')
+
 from nltk.corpus import reuters
 
 from torch.utils.data import Dataset
-import torch
 
 
 class Reuters(Dataset):
@@ -15,10 +17,11 @@ class Reuters(Dataset):
         self.encodings = encodings
         self.labels = labels
         self.classes = classes
-        
+
     @classmethod
     def splits(cls, tokenizer, r8=False, val_size=0.1):
-        """Creates the train, test, and validation splits for R52 or R8.
+        """
+        Creates the train, test, and validation splits for R52 or R8.
 
         Args:
             tokenizer (Tokenizer): Hugging Face tokenizer to encode the 3 dataset splits.
@@ -29,9 +32,9 @@ class Reuters(Dataset):
             train_split (Dataset): Training split.
             test_split (Dataset): Test split.
             val_split (Dataset): Validation split.
-        """        
+        """
         (train_docs, test_docs, val_docs), unique_cls = cls.prepare_reuters(r8, val_size)
-        
+
         # Maybe this should be in a function
         train_texts, train_labels = cls._prepare_split(train_docs, unique_cls)
         train_encodings = tokenizer(train_texts, truncation=True, padding=True)
@@ -46,36 +49,40 @@ class Reuters(Dataset):
         val_split = cls(val_encodings, val_labels, unique_cls)
 
         return train_split, test_split, val_split
-    
+
     @staticmethod
     def prepare_reuters(r8=False, val_size=0.1):
-        """Filters out all documents which have more or less than 1 class. Then filters out all classes which have no remaining documents.
+        """
+        Filters out all documents which have more or less than 1 class.
+        Then filters out all classes which have no remaining documents.
 
         Args:
             r8 (bool, optional): R8 is constructed by taking only the top 10 (original) classes. Defaults to False.
             val_size (float, optional): Proportion of training documents to include in the validation set.
 
         Returns:
-            doc_splits (tupple): Tupple containing 3 List of training, test, and validation documents.
+            doc_splits (tuple): Tuple containing 3 List of training, test, and validation documents.
             unique_classes (List): List of Strings containing the class names sorted in alphabetical order.
-        """    
+        """
         # Filter out docs which don't have exactly 1 class
         data = defaultdict(lambda: {'train': [], 'test': []})
+
         for doc in reuters.fileids():
-            if len(reuters.categories(doc)) == 1:
+            categories = reuters.categories(doc)
+            if len(categories) == 1:
                 if doc.startswith('training'):
-                    data[reuters.categories(doc)[0]]['train'].append(doc)
+                    data[categories[0]]['train'].append(doc)
                 if doc.startswith('test'):
-                    data[reuters.categories(doc)[0]]['test'].append(doc)
+                    data[categories[0]]['test'].append(doc)
 
         # Filter out classes which have no remaining docs
-        for cls in reuters.categories():
-            if len(data[cls]['train']) < 1 or len(data[cls]['test']) < 1:
-                data.pop(cls, None)
-        
+        for cat in reuters.categories():
+            if len(data[cat]['train']) < 1 or len(data[cat]['test']) < 1:
+                data.pop(cat, None)
+
         if r8:
             # Choose top 10 classes and then select the ones which still remain after filtering
-            popular = sorted(reuters.categories(), key=lambda cls: len(reuters.fileids(cls)), reverse=True)[:10]
+            popular = sorted(reuters.categories(), key=lambda clz: len(reuters.fileids(clz)), reverse=True)[:10]
             data = dict([(cls, splits) for (cls, splits) in data.items() if cls in popular])
 
         # Create splits
@@ -92,35 +99,36 @@ class Reuters(Dataset):
         unique_classes = sorted(data.keys())
 
         return (train_docs, test_docs, val_docs), unique_classes
-    
+
     @staticmethod
     def _prepare_split(docs, classes):
-        """Extract the text and labels of each documents.
+        """
+        Extract the text and labels of each documents.
 
         Args:
-            docs (List): List of document names from which the texts and labels will be extracted. 
+            docs (List): List of document names from which the texts and labels will be extracted.
             classes (List): List of unique class names sorted in alphabetical order.
 
         Returns:
             texts (List): List of Strings containing the text of the documents.
             labels (List): List of int containing the labels of the documents.
-        """   
+        """
         texts = []
         labels = []
         for doc in docs:
             text = ' '.join(reuters.words(doc))
-            cls = reuters.categories(doc)[0]
+            clz = reuters.categories(doc)[0]
             texts.append(text)
-            labels.append(classes.index(cls))
-        
+            labels.append(classes.index(clz))
+
         return texts, labels
-    
+
     def __getitem__(self, idx):
         # assumes that the encodings were created using a HuggingFace tokenizer
         item = {key: torch.tensor(val[idx]) for key, val in self.encodings.items()}
         item["labels"] = torch.tensor(self.labels[idx])
         return item
-    
+
     def __len__(self):
         return len(self.labels)
 
@@ -128,44 +136,47 @@ class Reuters(Dataset):
 class R52(Reuters):
     """
     Wrapper for the R52 dataset.
-    """    
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
     @classmethod
-    def splits(cls, *args, **kwargs):
-        return super().splits(r8=False, *args, **kwargs)
+    def splits(cls, tokenizer, *args, **kwargs):
+        return super().splits(tokenizer, r8=False, *args, **kwargs)
 
 
 class R8(Reuters):
     """
     Wrapper for the R8 dataset.
-    """    
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
     @classmethod
-    def splits(cls, *args, **kwargs):
-        return super().splits(r8=True, *args, **kwargs)
+    def splits(cls, tokenizer, *args, **kwargs):
+        return super().splits(tokenizer, r8=True, *args, **kwargs)
+
 
 if __name__ == "__main__":
     from transformers import RobertaTokenizer
     from torch.utils.data import DataLoader
+
     tokenizer = RobertaTokenizer.from_pretrained("roberta-base")
 
-    trainset, testset, valset = R52.splits(tokenizer, val_size=0.1)
-    print("train size=", len(trainset))
-    print("test size=", len(testset))
-    print("val size=", len(valset))
+    train_set, test_set, val_set = R52.splits(tokenizer)
+    print("train size=", len(train_set))
+    print("test size=", len(test_set))
+    print("val size=", len(val_set))
 
-    trainloader = DataLoader(trainset, batch_size=2, shuffle=True)
+    train_loader = DataLoader(train_set, batch_size=2, shuffle=True)
 
-    for data in trainloader:
-        input_ids = data["input_ids"]
-        attention_mask = data["attention_mask"]
-        labels = data["labels"]
+    for data_batch in train_loader:
+        input_ids = data_batch["input_ids"]
+        attention_mask = data_batch["attention_mask"]
+        d_labels = data_batch["labels"]
         print(input_ids)
         print(attention_mask)
-        print(labels)
+        print(d_labels)
         break
-

--- a/reuters_text.ipynb
+++ b/reuters_text.ipynb
@@ -28,38 +28,24 @@
      "output_type": "stream",
      "text": [
       "[nltk_data] Downloading package reuters to /home/mat/nltk_data...\n",
-      "[nltk_data]   Package reuters is already up-to-date!\n",
-      "[nltk_data] Downloading package punkt to /home/mat/nltk_data...\n",
-      "[nltk_data]   Package punkt is already up-to-date!\n"
+      "[nltk_data]   Package reuters is already up-to-date!\n"
      ]
     }
    ],
    "source": [
-    "from torchtext.data import BucketIterator, Field\n",
-    "from torchtext.vocab import GloVe\n",
-    "\n",
+    "from torch.utils.data import DataLoader\n",
+    "from transformers import RobertaTokenizer\n",
     "from datasets.reuters_text import R8, R52"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "53b2ab39",
+   "id": "1fe207ed",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/field.py:150: UserWarning: Field class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ID = Field(sequential=False, include_lengths=False)\n",
-    "TEXT = Field(sequential=True, lower=True, include_lengths=True, batch_first=True)\n",
-    "LABEL = Field(sequential=False, include_lengths=False)"
+    "tokenizer = RobertaTokenizer.from_pretrained(\"roberta-base\")"
    ]
   },
   {
@@ -67,19 +53,10 @@
    "execution_count": 3,
    "id": "9091d557",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/example.py:78: UserWarning: Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.', UserWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "r52_train, r52_test, r52_val = R52.splits(ID, TEXT, LABEL, val_size=0.1)\n",
-    "r8_train,  r8_test, r8_val  = R8.splits(ID, TEXT, LABEL, val_size=0.1)"
+    "r52_train, r52_test, r52_val = R52.splits(tokenizer, val_size=0.1)\n",
+    "r8_train,  r8_test, r8_val  = R8.splits(tokenizer, val_size=0.1)"
    ]
   },
   {
@@ -120,162 +97,29 @@
    "execution_count": 5,
    "id": "b29c705d",
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "ID.build_vocab(r52_train)\n",
-    "TEXT.build_vocab(r52_train, vectors=GloVe(name='840B', dim=300, max_vectors=10000))\n",
-    "LABEL.build_vocab(r52_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "a28b8cd2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/iterator.py:48: UserWarning: BucketIterator class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
-     ]
-    }
-   ],
-   "source": [
-    "r52_train_iter, r52_test_iter, r52_val_iter = BucketIterator.splits(\n",
-    "    (r52_train, r52_test, r52_val), \n",
-    "    batch_size=4,\n",
-    "    sort=False\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "69e0700a",
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "[torchtext.data.batch.Batch of size 4]\n",
-      "\t[.id]:[torch.LongTensor of size 4]\n",
-      "\t[.text]:('[torch.LongTensor of size 4x489]', '[torch.LongTensor of size 4]')\n",
-      "\t[.label]:[torch.LongTensor of size 4]\n",
-      "tensor([1666, 2736, 4494, 1235])\n",
-      "tensor([ 3,  2, 25,  2])\n",
-      "['crude']\n",
-      "crude\n",
-      "These two labels should be the same: crude == crude\n",
-      "(tensor([[2396,  380, 4430,  ...,    1,    1,    1],\n",
-      "        [ 949,   20,   21,  ..., 1286,  928,    2],\n",
-      "        [ 235,   99,  793,  ...,    1,    1,    1],\n",
-      "        [8752, 5676,   10,  ...,    1,    1,    1]]), tensor([111, 489,  40,  22]))\n",
-      "\n",
-      "[torchtext.data.batch.Batch of size 4]\n",
-      "\t[.id]:[torch.LongTensor of size 4]\n",
-      "\t[.text]:('[torch.LongTensor of size 4x899]', '[torch.LongTensor of size 4]')\n",
-      "\t[.label]:[torch.LongTensor of size 4]\n",
-      "tensor([0, 0, 0, 0])\n",
-      "tensor([4, 4, 4, 4])\n",
-      "(tensor([[1989, 1201, 3241,  ...,    4, 1065,    2],\n",
-      "        [ 130,  629,  891,  ...,    1,    1,    1],\n",
-      "        [ 239,  187, 1475,  ...,    1,    1,    1],\n",
-      "        [ 130,  629,  891,  ...,    1,    1,    1]]), tensor([899, 233, 257, 233]))\n",
-      "\n",
-      "[torchtext.data.batch.Batch of size 4]\n",
-      "\t[.id]:[torch.LongTensor of size 4]\n",
-      "\t[.text]:('[torch.LongTensor of size 4x101]', '[torch.LongTensor of size 4]')\n",
-      "\t[.label]:[torch.LongTensor of size 4]\n",
-      "tensor([0, 0, 0, 0])\n",
-      "tensor([ 2, 11,  1,  1])\n",
-      "(tensor([[    0,    10,  3867,     0,  1127,   332,    20,    21,    19,     0,\n",
-      "            57,    26,    10,     4,    20,    21,    19,  3867,  1008,     2,\n",
-      "             0,    57,    26,    77,   857,    27,   155,   338,    14,   287,\n",
-      "           332,     5,   144,     5,     4,  1765,  5008,  2391,     5,  1144,\n",
-      "           579,    57,     2,     0,     9,    17,    10,     4,     0,   497,\n",
-      "            38,   363,   804,     8,   133,    23,  1550,   167,     7,     4,\n",
-      "          5008,  2391,     2,     0,  2722,   287,    33,     3,    56,  1122,\n",
-      "            35,     8,    64,   121,     3,    17,    49,  1781,    54,   569,\n",
-      "           133,    11,    15,     5,   242,     6,  1144,     2,     0,   416,\n",
-      "          1144,   579,    57,   179,    71,    28,     3,     4,    42,     9,\n",
-      "             2],\n",
-      "        [14502,  3724,    57,   702,   275,  3351, 14502,  3724,    57,     9,\n",
-      "           428,  1180,    27,     4, 13091,  9713,  1091,  1024,     4,   370,\n",
-      "            14,  1401, 13275,   137,     8,  6324,     5,   616,  1025,     2,\n",
-      "          3351,  5329,    30,    80,    87,     2,   335,  1038,     5,   275,\n",
-      "           100,   452,  1163,   137,     8,   704,    14,  3116,  7963,    37,\n",
-      "             8,  2670,     5,  1336,     6,   357,  1025,     6,    80,    24,\n",
-      "             2,    24,  1038,     5,   275,   100,  1163,   137,     8,   568,\n",
-      "            14,  3116,  7963,    37,     8,  2670,     5,   522,     6,  3773,\n",
-      "          1025,     2,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1],\n",
-      "        [    0,  1838,    20,    21,    19,     0,    26,   305,   822,   135,\n",
-      "             0,  1838,    57,     9,    29,   148,   701,    54,   822,   317,\n",
-      "           135,     5,    90,    25,   100,    60,     3,    29,   107,   519,\n",
-      "             3,   430,    91,   356,     6,   623,     5,   124,    91,   129,\n",
-      "             2,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1,     1,     1,     1,     1,     1,     1,     1,     1,     1,\n",
-      "             1],\n",
-      "        [ 3685,    20,    21,    19, 10330,    26,     6,   374,   276,    18,\n",
-      "            13,    67,  3685,    89,    46,     9,    17,   286,     6,   374,\n",
-      "           134,    23,     5,     4,   157,    68,     5,    29, 10219,  3286,\n",
-      "            89,    46,   159,     6,  3685,    89,   200,     2,     4,    42,\n",
-      "             9,    17,  1380,     6,   374,    70,    60,     5, 10219,  3286,\n",
-      "            16,   363,   188,  3685,    67,   378,     6,   200,     5,   124,\n",
-      "            91,   356,     2,     4,   642,    32,   832,    16,    98,   149,\n",
-      "             3,     4,    42,    88,     9,     2,    17,     9,     4, 10219,\n",
-      "            67,    38,    82,     7,     4,   137,    14,     4,    14,  2070,\n",
-      "            94,   164,     4,  9456,     0,     2,     1,     1,     1,     1,\n",
-      "             1]]), tensor([101,  82,  41,  96]))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/mat/miniconda3/envs/atcs-project/lib/python3.8/site-packages/torchtext/data/batch.py:23: UserWarning: Batch class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
+      "tensor([[    0,   725, 11969,  ...,     1,     1,     1],\n",
+      "        [    0, 26107,   359,  ...,     1,     1,     1]])\n",
+      "tensor([[1, 1, 1,  ..., 0, 0, 0],\n",
+      "        [1, 1, 1,  ..., 0, 0, 0]])\n",
+      "tensor([12, 12])\n"
      ]
     }
    ],
    "source": [
-    "# Import reuters just to prove a point\n",
-    "from nltk.corpus import reuters\n",
+    "r52_train_dataloader = DataLoader(r52_train, batch_size=2, shuffle=True)\n",
     "\n",
-    "for x in r52_train_iter:\n",
-    "    print(x)\n",
-    "    print(x.id)\n",
-    "    print(x.label)\n",
-    "    print(reuters.categories(ID.vocab.itos[x.id[0]]))\n",
-    "    print(LABEL.vocab.itos[x.label[0]])\n",
-    "    print('These two labels should be the same: {} == {}'.format(\n",
-    "        reuters.categories(ID.vocab.itos[x.id[0]])[0],\n",
-    "        LABEL.vocab.itos[x.label[0]]))\n",
-    "\n",
-    "    print(x.text) # Padding is 1\n",
-    "    break\n",
-    "\n",
-    "for x in r52_test_iter:\n",
-    "    print(x)\n",
-    "    print(x.id)\n",
-    "    print(x.label)\n",
-    "    print(x.text) # Padding is 1\n",
-    "    break\n",
-    "    \n",
-    "for x in r52_val_iter:\n",
-    "    print(x)\n",
-    "    print(x.id)\n",
-    "    print(x.label)\n",
-    "    print(x.text) # Padding is 1\n",
+    "for data in r52_train_dataloader:\n",
+    "    input_ids = data[\"input_ids\"]\n",
+    "    attention_mask = data[\"attention_mask\"]\n",
+    "    labels = data[\"labels\"]\n",
+    "    print(input_ids)\n",
+    "    print(attention_mask)\n",
+    "    print(labels)\n",
     "    break"
    ]
   },


### PR DESCRIPTION
The interface is mostly the same with ```R8.splits()``` but I removed the ```Field``` parameters and instead added a huggingface ```Tokenizer```. I tested it with the one from roberta and it seems to work (see the notebook).
To iterate over the dataset, instead of using ```BucketIterator```, you can now use a pytorch ```DataLoader```.